### PR TITLE
Fix transactionEvent value types (number instead of string).

### DIFF
--- a/cp.html
+++ b/cp.html
@@ -628,13 +628,13 @@
 					},
 					"transactionData": {
 						"id": lastTranId,
-						"remoteStartId": "0",
+						"remoteStartId": 0,
 						"chargingState": charge_state
 					},
 					"meterValue": [{
 						"timestamp": formatDate(new Date()),
 						"sampledValue": [{
-							"value": "0"
+							"value": 0
 						}]
 					}]
 				}]);
@@ -658,15 +658,15 @@
 					},
 					"transactionData": {
 						"id": lastTranId,
-						"remoteStartId": "0",
+						"remoteStartId": 0,
 						"chargingState": charger_state
 					},
 					"meterValue": [{
 						"timestamp": formatDate(new Date()),
 						"sampledValue": [{
-							"value": "10"
+							"value": 10
 						}, {
-							"value": "15",
+							"value": 15,
 							"context": "Sample.Periodic",
 							"measurand": "Energy.Reactive.Export.Register",
 							"phase": "L1",
@@ -702,12 +702,12 @@
 					},
 					"transactionData": {
 						"id": lastTranId,
-						"remoteStartId": "0"
+						"remoteStartId": 0
 					},
 					"meterValue": [{
 						"timestamp": formatDate(new Date()),
 						"sampledValue": [{
-							"value": "20"
+							"value": 20
 						}]
 					}]
 				}]);


### PR DESCRIPTION
Hey David,
first of all thanks a lot for sharing this OCPP 2.0 simulator :) Even though it's "simple" it is really useful!

I observed that some of the values of the TransactionEvent messages do not match with the OCPP spec (they were strings but should be numbers) and decided to fix that.

Wanna merge it? ;-)